### PR TITLE
feat: add index.html with Red Dwarf short story

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>A Day Aboard Red Dwarf</title>
+  <style>
+    body {
+      font-family: Georgia, serif;
+      font-size: 1.1rem;
+      line-height: 1.75;
+      color: #222;
+      background: #f9f6f0;
+      margin: 0;
+      padding: 2rem 1rem;
+    }
+    main {
+      max-width: 680px;
+      margin: 0 auto;
+    }
+    h1 {
+      font-size: 1.8rem;
+      margin-bottom: 0.25rem;
+    }
+    p {
+      margin: 1em 0;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>A Day Aboard Red Dwarf</h1>
+
+    <p>
+      It started, as most disasters on Red Dwarf did, with Lister making a
+      curry. He had commandeered the sleeping quarters' hot plate, blissfully
+      ignoring the smoke alarm, and was humming an off-key rendition of
+      "Wonderwall" when Rimmer materialised in the doorway, arms folded,
+      expression arranged into its default setting of barely-contained
+      displeasure.
+    </p>
+
+    <p>
+      "Lister, that smell is violating at least six of my personal space
+      regulations," Rimmer announced, projecting his hologrammatic form to
+      full height—a trick that fooled no one. "I have filed a formal complaint
+      with the ship's computer. Again."
+    </p>
+
+    <p>
+      A moment later, Holly's face blinked onto the monitor mounted above
+      the bunk. The ship's AI regarded both of them with the serene patience
+      of someone who had been alone for three million years and had learned
+      not to expect much. "I got the complaint," Holly said. "I've also
+      received forty-seven previous ones. I'm using them as a screensaver."
+    </p>
+
+    <p>
+      Cat appeared in the doorway seconds later, drawn—as always—by either
+      food or an opportunity to look at himself in a reflective surface.
+      He was wearing a silver lamé jacket and carrying a small mirror. He
+      sniffed once, recoiled, and pointed an accusatory finger at the
+      saucepan. "That is an offence against my nostrils, bud. And my
+      nostrils are the most sophisticated sensory equipment on this ship."
+    </p>
+
+    <p>
+      "Mr. Lister, sir." Kryten appeared behind Cat, clasping his hands
+      together with the anxious courtesy of a mechanoid who has seen too
+      many avoidable catastrophes. "I have taken the liberty of preparing a
+      nutritional risk assessment of the current dish. The results are…
+      characteristically alarming. Might I suggest the protein substitute I
+      prepared earlier? It has a flavour profile I would describe as
+      'inoffensive.'"
+    </p>
+
+    <p>
+      Lister smiled, lifted a spoonful, and blew on it. "It's fine," he
+      said. "Trust me."
+    </p>
+
+    <p>
+      Rimmer shuddered. Holly's screen went dark—tactful, for once. Cat
+      produced a small gas mask from somewhere inside his jacket. And Kryten,
+      duty-bound to the end, fetched a fire extinguisher—just in case.
+    </p>
+
+    <p>
+      Three million years from Earth, hurtling through the unknown reaches
+      of deep space, the crew of Red Dwarf sat down to dinner together. It
+      was, all things considered, a perfectly normal Tuesday.
+    </p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds `index.html` at the repository root with a short story featuring all five main Red Dwarf characters.

Closes #18

## Changes

- **New file**: `index.html` — valid HTML5 page with a self-contained short story mentioning Lister, Rimmer, Cat, Kryten, and Holly. Includes a `<style>` block for minimal, readable layout. No external dependencies.

## Acceptance Criteria

- [x] `index.html` exists at repository root and is valid HTML5
- [x] Story mentions all five characters: Lister, Rimmer, Cat, Kryten, Holly
- [x] No existing files modified
- [x] Page renders correctly in a browser (single self-contained file)